### PR TITLE
Expose AtomicOperations trait for public use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,13 +629,13 @@ macro_rules! atomic_int {
 
         #[cfg(target_arch = "msp430")]
         impl AtomicOperations for $int_type {
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_store(dst: *mut Self, val: Self) {
                 asm!(concat!("mov", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_load(dst: *const Self) -> Self {
                 let out;
                 asm!(concat!("mov", $asm_suffix, " $1, $0")
@@ -643,31 +643,31 @@ macro_rules! atomic_int {
                 out
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_add(dst: *mut Self, val: Self) {
                 asm!(concat!("add", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_sub(dst: *mut Self, val: Self) {
                 asm!(concat!("sub", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_and(dst: *mut Self, val: Self) {
                 asm!(concat!("and", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_or(dst: *mut Self, val: Self) {
                 asm!(concat!("bis", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_xor(dst: *mut Self, val: Self) {
                 asm!(concat!("xor", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
@@ -676,37 +676,37 @@ macro_rules! atomic_int {
 
         #[cfg(not(target_arch = "msp430"))]
         impl AtomicOperations for $int_type {
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_store(dst: *mut Self, val: Self) {
                 ::core::intrinsics::atomic_store(dst, val);
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_load(dst: *const Self) -> Self {
                 ::core::intrinsics::atomic_load(dst)
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_add(dst: *mut Self, val: Self) {
                 ::core::intrinsics::atomic_xadd(dst, val);
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_sub(dst: *mut Self, val: Self) {
                 ::core::intrinsics::atomic_xsub(dst, val);
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_and(dst: *mut Self, val: Self) {
                 ::core::intrinsics::atomic_and(dst, val);
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_or(dst: *mut Self, val: Self) {
                 ::core::intrinsics::atomic_or(dst, val);
             }
 
-            #[inline]
+            #[inline(always)]
             unsafe fn atomic_xor(dst: *mut Self, val: Self) {
                 ::core::intrinsics::atomic_xor(dst, val);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ impl AtomicBool {
     /// ```
     #[inline]
     pub fn into_inner(self) -> bool {
-        unsafe { self.v.into_inner() != 0 }
+        self.v.into_inner() != 0
     }
 
     /// Loads a value from the bool.
@@ -379,7 +379,7 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     pub fn into_inner(self) -> *mut T {
-        unsafe { self.p.into_inner() }
+        self.p.into_inner()
     }
 
     /// Loads a value from the pointer.
@@ -500,7 +500,7 @@ macro_rules! atomic_int {
             /// ```
             #[inline]
             pub fn into_inner(self) -> $int_type {
-                unsafe { self.v.into_inner() }
+                 self.v.into_inner()
             }
 
             /// Loads a value from the atomic integer.
@@ -663,7 +663,7 @@ macro_rules! atomic_int {
 
             #[inline]
             unsafe fn atomic_or(dst: *mut Self, val: Self) {
-                asm!(concat!("or", $asm_suffix, " $1, $0")
+                asm!(concat!("bis", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
@@ -730,21 +730,30 @@ atomic_int! {
     u16 AtomicU16 ATOMIC_U16_INIT ".w"
 }
 
-atomic_int!{
+atomic_int! {
     isize AtomicIsize ATOMIC_ISIZE_INIT ".w"
 }
 
-atomic_int!{
+atomic_int! {
     usize AtomicUsize ATOMIC_USIZE_INIT ".w"
 }
 
-trait AtomicOperations {
+/// Atomic arithmetic and bitwise operations implemented for numerical types. Each operation is
+/// implemented with a single assembly instruction.
+pub trait AtomicOperations {
+    /// Store value into destination pointee.
     unsafe fn atomic_store(dst: *mut Self, val: Self);
+    /// Read value from destination pointee.
     unsafe fn atomic_load(dst: *const Self) -> Self;
+    /// Add value to destination pointee. Result may wrap around.
     unsafe fn atomic_add(dst: *mut Self, val: Self);
+    /// Subtract value from destination pointee. Result may wrap around.
     unsafe fn atomic_sub(dst: *mut Self, val: Self);
+    /// Clear all bits in destination pointee that are zeroed in value.
     unsafe fn atomic_and(dst: *mut Self, val: Self);
+    /// Set all bits in destination pointee that are set in value.
     unsafe fn atomic_or(dst: *mut Self, val: Self);
+    /// Toggle all bits in destination pointee that are set in value.
     unsafe fn atomic_xor(dst: *mut Self, val: Self);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,6 +662,12 @@ macro_rules! atomic_int {
             }
 
             #[inline(always)]
+            unsafe fn atomic_clear(dst: *mut Self, val: Self) {
+                asm!(concat!("bic", $asm_suffix, " $1, $0")
+                    :: "*m"(dst), "ir"(val) : "memory" : "volatile");
+            }
+
+            #[inline(always)]
             unsafe fn atomic_or(dst: *mut Self, val: Self) {
                 asm!(concat!("bis", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
@@ -699,6 +705,11 @@ macro_rules! atomic_int {
             #[inline(always)]
             unsafe fn atomic_and(dst: *mut Self, val: Self) {
                 ::core::intrinsics::atomic_and(dst, val);
+            }
+
+            #[inline(always)]
+            unsafe fn atomic_clear(dst: *mut Self, val: Self) {
+                ::core::intrinsics::atomic_and(dst, !val);
             }
 
             #[inline(always)]
@@ -751,6 +762,8 @@ pub trait AtomicOperations {
     unsafe fn atomic_sub(dst: *mut Self, val: Self);
     /// Clear all bits in destination pointee that are zeroed in value.
     unsafe fn atomic_and(dst: *mut Self, val: Self);
+    /// Clear all bits in destination pointee that are set in value
+    unsafe fn atomic_clear(dst: *mut Self, val: Self);
     /// Set all bits in destination pointee that are set in value.
     unsafe fn atomic_or(dst: *mut Self, val: Self);
     /// Toggle all bits in destination pointee that are set in value.


### PR DESCRIPTION
The internal AtomicOperations trait is pretty useful on its own so I made it public and added some documentation to it. My use case was atomically modifying hardware registers using atomic_and and atomic_or on the register addresses. 