### PR TITLE
Convert `asm!` to `llvm_asm!`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //! ```
 
 #![no_std]
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(const_fn)]
 #![cfg_attr(not(target_arch = "msp430"), feature(core_intrinsics))]
 
@@ -631,33 +631,33 @@ macro_rules! atomic_int {
         impl AtomicOperations for $int_type {
             #[inline(always)]
             unsafe fn atomic_store(dst: *mut Self, val: Self) {
-                asm!(concat!("mov", $asm_suffix, " $1, $0")
+                llvm_asm!(concat!("mov", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
             #[inline(always)]
             unsafe fn atomic_load(dst: *const Self) -> Self {
                 let out;
-                asm!(concat!("mov", $asm_suffix, " $1, $0")
+                llvm_asm!(concat!("mov", $asm_suffix, " $1, $0")
                     : "=r"(out) : "*m"(dst) : "memory" : "volatile");
                 out
             }
 
             #[inline(always)]
             unsafe fn atomic_add(dst: *mut Self, val: Self) {
-                asm!(concat!("add", $asm_suffix, " $1, $0")
+                llvm_asm!(concat!("add", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
             #[inline(always)]
             unsafe fn atomic_sub(dst: *mut Self, val: Self) {
-                asm!(concat!("sub", $asm_suffix, " $1, $0")
+                llvm_asm!(concat!("sub", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
             #[inline(always)]
             unsafe fn atomic_and(dst: *mut Self, val: Self) {
-                asm!(concat!("and", $asm_suffix, " $1, $0")
+                llvm_asm!(concat!("and", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
@@ -669,13 +669,13 @@ macro_rules! atomic_int {
 
             #[inline(always)]
             unsafe fn atomic_or(dst: *mut Self, val: Self) {
-                asm!(concat!("bis", $asm_suffix, " $1, $0")
+                llvm_asm!(concat!("bis", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 
             #[inline(always)]
             unsafe fn atomic_xor(dst: *mut Self, val: Self) {
-                asm!(concat!("xor", $asm_suffix, " $1, $0")
+                llvm_asm!(concat!("xor", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,7 +663,7 @@ macro_rules! atomic_int {
 
             #[inline(always)]
             unsafe fn atomic_clear(dst: *mut Self, val: Self) {
-                asm!(concat!("bic", $asm_suffix, " $1, $0")
+                llvm_asm!(concat!("bic", $asm_suffix, " $1, $0")
                     :: "*m"(dst), "ir"(val) : "memory" : "volatile");
             }
 


### PR DESCRIPTION
Self-explanatory. Eventually we'll convert back to the new `asm!` macro and do a release (`v0.2.0` or `v0.1.3`?). For the time being, could you publish a new `v0.1.2` release so recent nightlies can compile the crate without using a fork?