### PR TITLE
Use core atomic types instead of intrinsics on non-MSP430 targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,9 @@
 //! ```
 
 #![no_std]
-#![feature(asm_experimental_arch)]
-#![cfg_attr(not(target_arch = "msp430"), feature(core_intrinsics))]
+#![cfg_attr(target_arch = "msp430", feature(asm_experimental_arch))]
 
+#[cfg(target_arch = "msp430")]
 use core::arch::asm;
 use core::cell::UnsafeCell;
 use core::fmt;
@@ -681,42 +681,50 @@ macro_rules! atomic_int {
         impl AtomicOperations for $int_type {
             #[inline(always)]
             unsafe fn atomic_store(dst: *mut Self, val: Self) {
-                ::core::intrinsics::atomic_store(dst, val);
+                (*(dst as *const ::core::sync::atomic::$atomic_type))
+                    .store(val, ::core::sync::atomic::Ordering::SeqCst);
             }
 
             #[inline(always)]
             unsafe fn atomic_load(dst: *const Self) -> Self {
-                ::core::intrinsics::atomic_load(dst)
+                (*(dst as *const ::core::sync::atomic::$atomic_type))
+                    .load(::core::sync::atomic::Ordering::SeqCst)
             }
 
             #[inline(always)]
             unsafe fn atomic_add(dst: *mut Self, val: Self) {
-                ::core::intrinsics::atomic_xadd(dst, val);
+                (*(dst as *const ::core::sync::atomic::$atomic_type))
+                    .fetch_add(val, ::core::sync::atomic::Ordering::SeqCst);
             }
 
             #[inline(always)]
             unsafe fn atomic_sub(dst: *mut Self, val: Self) {
-                ::core::intrinsics::atomic_xsub(dst, val);
+                (*(dst as *const ::core::sync::atomic::$atomic_type))
+                    .fetch_sub(val, ::core::sync::atomic::Ordering::SeqCst);
             }
 
             #[inline(always)]
             unsafe fn atomic_and(dst: *mut Self, val: Self) {
-                ::core::intrinsics::atomic_and(dst, val);
+                (*(dst as *const ::core::sync::atomic::$atomic_type))
+                    .fetch_and(val, ::core::sync::atomic::Ordering::SeqCst);
             }
 
             #[inline(always)]
             unsafe fn atomic_clear(dst: *mut Self, val: Self) {
-                ::core::intrinsics::atomic_and(dst, !val);
+                (*(dst as *const ::core::sync::atomic::$atomic_type))
+                    .fetch_and(!val, ::core::sync::atomic::Ordering::SeqCst);
             }
 
             #[inline(always)]
             unsafe fn atomic_or(dst: *mut Self, val: Self) {
-                ::core::intrinsics::atomic_or(dst, val);
+                (*(dst as *const ::core::sync::atomic::$atomic_type))
+                    .fetch_or(val, ::core::sync::atomic::Ordering::SeqCst);
             }
 
             #[inline(always)]
             unsafe fn atomic_xor(dst: *mut Self, val: Self) {
-                ::core::intrinsics::atomic_xor(dst, val);
+                (*(dst as *const ::core::sync::atomic::$atomic_type))
+                    .fetch_xor(val, ::core::sync::atomic::Ordering::SeqCst);
             }
         }
     }


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/97423, build on non-MSP430 targets is failing.



<details><summary>log</summary>

```
error[E0425]: cannot find function `atomic_load` in module `core::intrinsics`
   --> src/lib.rs:684:37
    |
684 |                   ::core::intrinsics::atomic_load(dst)
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
720 | / atomic_int! {
721 | |     i8 AtomicI8 ATOMIC_I8_INIT ".b"
722 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xadd` in module `core::intrinsics`
   --> src/lib.rs:689:37
    |
689 |                   ::core::intrinsics::atomic_xadd(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
720 | / atomic_int! {
721 | |     i8 AtomicI8 ATOMIC_I8_INIT ".b"
722 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xsub` in module `core::intrinsics`
   --> src/lib.rs:694:37
    |
694 |                   ::core::intrinsics::atomic_xsub(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
720 | / atomic_int! {
721 | |     i8 AtomicI8 ATOMIC_I8_INIT ".b"
722 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:699:37
    |
699 |                   ::core::intrinsics::atomic_and(dst, val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
720 | / atomic_int! {
721 | |     i8 AtomicI8 ATOMIC_I8_INIT ".b"
722 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:704:37
    |
704 |                   ::core::intrinsics::atomic_and(dst, !val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
720 | / atomic_int! {
721 | |     i8 AtomicI8 ATOMIC_I8_INIT ".b"
722 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_or` in module `core::intrinsics`
   --> src/lib.rs:709:37
    |
709 |                   ::core::intrinsics::atomic_or(dst, val);
    |                                       ^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
720 | / atomic_int! {
721 | |     i8 AtomicI8 ATOMIC_I8_INIT ".b"
722 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xor` in module `core::intrinsics`
   --> src/lib.rs:714:37
    |
714 |                   ::core::intrinsics::atomic_xor(dst, val);
    |                                       ^^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
720 | / atomic_int! {
721 | |     i8 AtomicI8 ATOMIC_I8_INIT ".b"
722 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_load` in module `core::intrinsics`
   --> src/lib.rs:684:37
    |
684 |                   ::core::intrinsics::atomic_load(dst)
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
724 | / atomic_int! {
725 | |     u8 AtomicU8 ATOMIC_U8_INIT ".b"
726 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xadd` in module `core::intrinsics`
   --> src/lib.rs:689:37
    |
689 |                   ::core::intrinsics::atomic_xadd(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
724 | / atomic_int! {
725 | |     u8 AtomicU8 ATOMIC_U8_INIT ".b"
726 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xsub` in module `core::intrinsics`
   --> src/lib.rs:694:37
    |
694 |                   ::core::intrinsics::atomic_xsub(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
724 | / atomic_int! {
725 | |     u8 AtomicU8 ATOMIC_U8_INIT ".b"
726 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:699:37
    |
699 |                   ::core::intrinsics::atomic_and(dst, val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
724 | / atomic_int! {
725 | |     u8 AtomicU8 ATOMIC_U8_INIT ".b"
726 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:704:37
    |
704 |                   ::core::intrinsics::atomic_and(dst, !val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
724 | / atomic_int! {
725 | |     u8 AtomicU8 ATOMIC_U8_INIT ".b"
726 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_or` in module `core::intrinsics`
   --> src/lib.rs:709:37
    |
709 |                   ::core::intrinsics::atomic_or(dst, val);
    |                                       ^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
724 | / atomic_int! {
725 | |     u8 AtomicU8 ATOMIC_U8_INIT ".b"
726 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xor` in module `core::intrinsics`
   --> src/lib.rs:714:37
    |
714 |                   ::core::intrinsics::atomic_xor(dst, val);
    |                                       ^^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
724 | / atomic_int! {
725 | |     u8 AtomicU8 ATOMIC_U8_INIT ".b"
726 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_load` in module `core::intrinsics`
   --> src/lib.rs:684:37
    |
684 |                   ::core::intrinsics::atomic_load(dst)
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
728 | / atomic_int! {
729 | |     i16 AtomicI16 ATOMIC_I16_INIT ".w"
730 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xadd` in module `core::intrinsics`
   --> src/lib.rs:689:37
    |
689 |                   ::core::intrinsics::atomic_xadd(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
728 | / atomic_int! {
729 | |     i16 AtomicI16 ATOMIC_I16_INIT ".w"
730 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xsub` in module `core::intrinsics`
   --> src/lib.rs:694:37
    |
694 |                   ::core::intrinsics::atomic_xsub(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
728 | / atomic_int! {
729 | |     i16 AtomicI16 ATOMIC_I16_INIT ".w"
730 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:699:37
    |
699 |                   ::core::intrinsics::atomic_and(dst, val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
728 | / atomic_int! {
729 | |     i16 AtomicI16 ATOMIC_I16_INIT ".w"
730 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:704:37
    |
704 |                   ::core::intrinsics::atomic_and(dst, !val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
728 | / atomic_int! {
729 | |     i16 AtomicI16 ATOMIC_I16_INIT ".w"
730 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_or` in module `core::intrinsics`
   --> src/lib.rs:709:37
    |
709 |                   ::core::intrinsics::atomic_or(dst, val);
    |                                       ^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
728 | / atomic_int! {
729 | |     i16 AtomicI16 ATOMIC_I16_INIT ".w"
730 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xor` in module `core::intrinsics`
   --> src/lib.rs:714:37
    |
714 |                   ::core::intrinsics::atomic_xor(dst, val);
    |                                       ^^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
728 | / atomic_int! {
729 | |     i16 AtomicI16 ATOMIC_I16_INIT ".w"
730 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_load` in module `core::intrinsics`
   --> src/lib.rs:684:37
    |
684 |                   ::core::intrinsics::atomic_load(dst)
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
732 | / atomic_int! {
733 | |     u16 AtomicU16 ATOMIC_U16_INIT ".w"
734 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xadd` in module `core::intrinsics`
   --> src/lib.rs:689:37
    |
689 |                   ::core::intrinsics::atomic_xadd(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
732 | / atomic_int! {
733 | |     u16 AtomicU16 ATOMIC_U16_INIT ".w"
734 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xsub` in module `core::intrinsics`
   --> src/lib.rs:694:37
    |
694 |                   ::core::intrinsics::atomic_xsub(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
732 | / atomic_int! {
733 | |     u16 AtomicU16 ATOMIC_U16_INIT ".w"
734 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:699:37
    |
699 |                   ::core::intrinsics::atomic_and(dst, val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
732 | / atomic_int! {
733 | |     u16 AtomicU16 ATOMIC_U16_INIT ".w"
734 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:704:37
    |
704 |                   ::core::intrinsics::atomic_and(dst, !val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
732 | / atomic_int! {
733 | |     u16 AtomicU16 ATOMIC_U16_INIT ".w"
734 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_or` in module `core::intrinsics`
   --> src/lib.rs:709:37
    |
709 |                   ::core::intrinsics::atomic_or(dst, val);
    |                                       ^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
732 | / atomic_int! {
733 | |     u16 AtomicU16 ATOMIC_U16_INIT ".w"
734 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xor` in module `core::intrinsics`
   --> src/lib.rs:714:37
    |
714 |                   ::core::intrinsics::atomic_xor(dst, val);
    |                                       ^^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
732 | / atomic_int! {
733 | |     u16 AtomicU16 ATOMIC_U16_INIT ".w"
734 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_load` in module `core::intrinsics`
   --> src/lib.rs:684:37
    |
684 |                   ::core::intrinsics::atomic_load(dst)
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
736 | / atomic_int! {
737 | |     isize AtomicIsize ATOMIC_ISIZE_INIT ".w"
738 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xadd` in module `core::intrinsics`
   --> src/lib.rs:689:37
    |
689 |                   ::core::intrinsics::atomic_xadd(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
736 | / atomic_int! {
737 | |     isize AtomicIsize ATOMIC_ISIZE_INIT ".w"
738 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xsub` in module `core::intrinsics`
   --> src/lib.rs:694:37
    |
694 |                   ::core::intrinsics::atomic_xsub(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
736 | / atomic_int! {
737 | |     isize AtomicIsize ATOMIC_ISIZE_INIT ".w"
738 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:699:37
    |
699 |                   ::core::intrinsics::atomic_and(dst, val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
736 | / atomic_int! {
737 | |     isize AtomicIsize ATOMIC_ISIZE_INIT ".w"
738 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:704:37
    |
704 |                   ::core::intrinsics::atomic_and(dst, !val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
736 | / atomic_int! {
737 | |     isize AtomicIsize ATOMIC_ISIZE_INIT ".w"
738 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_or` in module `core::intrinsics`
   --> src/lib.rs:709:37
    |
709 |                   ::core::intrinsics::atomic_or(dst, val);
    |                                       ^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
736 | / atomic_int! {
737 | |     isize AtomicIsize ATOMIC_ISIZE_INIT ".w"
738 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xor` in module `core::intrinsics`
   --> src/lib.rs:714:37
    |
714 |                   ::core::intrinsics::atomic_xor(dst, val);
    |                                       ^^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
736 | / atomic_int! {
737 | |     isize AtomicIsize ATOMIC_ISIZE_INIT ".w"
738 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_load` in module `core::intrinsics`
   --> src/lib.rs:684:37
    |
684 |                   ::core::intrinsics::atomic_load(dst)
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
740 | / atomic_int! {
741 | |     usize AtomicUsize ATOMIC_USIZE_INIT ".w"
742 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xadd` in module `core::intrinsics`
   --> src/lib.rs:689:37
    |
689 |                   ::core::intrinsics::atomic_xadd(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
740 | / atomic_int! {
741 | |     usize AtomicUsize ATOMIC_USIZE_INIT ".w"
742 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xsub` in module `core::intrinsics`
   --> src/lib.rs:694:37
    |
694 |                   ::core::intrinsics::atomic_xsub(dst, val);
    |                                       ^^^^^^^^^^^ not found in `core::intrinsics`
...
740 | / atomic_int! {
741 | |     usize AtomicUsize ATOMIC_USIZE_INIT ".w"
742 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:699:37
    |
699 |                   ::core::intrinsics::atomic_and(dst, val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
740 | / atomic_int! {
741 | |     usize AtomicUsize ATOMIC_USIZE_INIT ".w"
742 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_and` in module `core::intrinsics`
   --> src/lib.rs:704:37
    |
704 |                   ::core::intrinsics::atomic_and(dst, !val);
    |                                       ^^^^^^^^^^ not found in `core::intrinsics`
...
740 | / atomic_int! {
741 | |     usize AtomicUsize ATOMIC_USIZE_INIT ".w"
742 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_or` in module `core::intrinsics`
   --> src/lib.rs:709:37
    |
709 |                   ::core::intrinsics::atomic_or(dst, val);
    |                                       ^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
740 | / atomic_int! {
741 | |     usize AtomicUsize ATOMIC_USIZE_INIT ".w"
742 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find function `atomic_xor` in module `core::intrinsics`
   --> src/lib.rs:714:37
    |
714 |                   ::core::intrinsics::atomic_xor(dst, val);
    |                                       ^^^^^^^^^^ help: a function with a similar name exists: `atomic_store`
...
740 | / atomic_int! {
741 | |     usize AtomicUsize ATOMIC_USIZE_INIT ".w"
742 | | }
    | |_- in this macro invocation
    |
   ::: /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics.rs:523:5
    |
523 |       pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
    |       -------------------------------------------------------- similarly named function `atomic_store` defined here
    |
    = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)
```

</details>